### PR TITLE
call super in derived classes

### DIFF
--- a/src/nodes/doc.coffee
+++ b/src/nodes/doc.coffee
@@ -11,6 +11,7 @@ module.exports = class Doc extends Node
   # node - The comment node (a {Object})
   # options - The parser options (a {Object})
   constructor: (@node, @options) ->
+    super()
     try
       if @node
         trimmedComment = @leftTrimBlock(@node.comment.replace(/\u0091/gm, '').split('\n'))

--- a/src/nodes/file.coffee
+++ b/src/nodes/file.coffee
@@ -16,6 +16,7 @@ module.exports = class File extends Class
   # lineMapping - An object mapping the actual position of a member to its Donna one
   # options - Any additional parser options
   constructor: (@node, @fileName, @lineMapping, @options) ->
+    super()
     try
       @methods = []
       @variables = []

--- a/src/nodes/method.coffee
+++ b/src/nodes/method.coffee
@@ -17,6 +17,7 @@ module.exports = class Method extends Node
   # options - The parser options (a {Object})
   # comment - The comment node (a {Object})
   constructor: (@entity, @node, @lineMapping, @options, comment) ->
+    super()
     try
       @parameters = []
 

--- a/src/nodes/mixin.coffee
+++ b/src/nodes/mixin.coffee
@@ -14,6 +14,7 @@ module.exports = class Mixin extends Node
   # options - The parser options (a {Object})
   # comment - The comment node (a {Object})
   constructor: (@node, @fileName, @options, comment) ->
+    super()
     try
       @methods = []
       @variables = []

--- a/src/nodes/parameter.coffee
+++ b/src/nodes/parameter.coffee
@@ -12,6 +12,7 @@ module.exports = class Parameter extends Node
   # options - The parser options (a {Object})
   # optionized - A {Boolean} indicating if the parameter is a set of options
   constructor: (@node, @options, @optionized) ->
+    super()
 
   # Public: Get the full parameter signature.
   #

--- a/src/nodes/property.coffee
+++ b/src/nodes/property.coffee
@@ -27,6 +27,7 @@ module.exports = class Property extends Node
   # name - The filename (a {String})
   # comment - The comment node (a {Object})
   constructor: (@entity, @node, @lineMapping, @options, @name, comment) ->
+    super()
     @doc = new Doc(comment, @options)
 
     @setter  = false

--- a/src/nodes/variable.coffee
+++ b/src/nodes/variable.coffee
@@ -13,6 +13,7 @@ module.exports = class Variable extends Node
   # classType - A {Boolean} indicating if the class is a `class` or an `instance`
   # comment - The comment node (a {Object})
   constructor: (@entity, @node, @lineMapping, @options, @classType = false, comment = null) ->
+    super()
     try
       @doc = new Doc(comment, @options)
       @getName()

--- a/src/nodes/virtual_method.coffee
+++ b/src/nodes/virtual_method.coffee
@@ -15,6 +15,7 @@ module.exports = class VirtualMethod extends Node
   # doc - The property node (a {Object})
   # options - The parser options (a {Object})
   constructor: (@entity, @doc, @options) ->
+    super()
 
   # Public: Get the method type, either `class`, `instance` or `mixin`.
   #


### PR DESCRIPTION
### Identify the Bug

At https://github.com/atom/atom/issues/22099 section Motivation, I saw that there's an error:
```
npm test

> joanna@0.0.12 test
> mocha test        


C:\Users\Steven\Documents\GitHub\clones\joanna\node_modules\donna\src\nodes\file.coffee:20:7: error: Can't reference 'this' before calling super in derived class constructors
      @methods = []
      ^
```

### Description of the Change

Calls super in those classes

### Alternate Designs

None

### Possible Drawbacks

I'm not sure why super wasn't called in the first place, maybe I'm missing something.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Call super in derived classes
